### PR TITLE
Add PR lineage endpoint support

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,19 @@ This repository includes an MCP server implementation that provides convenient a
    }
    ```
 
-The MCP server provides tools for searching entities, getting entity details, and exploring upstream/downstream dependencies through your AI assistant.
+The MCP server provides tools for:
+- searching entities
+- getting entity details
+- exploring upstream/downstream dependencies
+- retrieving pull request lineage diff metadata
+- retrieving pull request lineage issues
+
+### Supported API Endpoints in This Repository
+- `GET /lineage/search`
+- `GET /lineage/entity/{entity_id}`
+- `GET /lineage/entity/{entity_id}/{direction}`
+- `GET /lineage/pr/issues/diff`
+- `GET /lineage/pr/issues`
 
 ## Additional Resources
 - Learn more about the API: [Getting Started with the Lineage API](https://docs.foundational.io/en/articles/10067204-getting-started-with-the-lineage-api)

--- a/hello_lineage_graph/foundational_api_wrapper.py
+++ b/hello_lineage_graph/foundational_api_wrapper.py
@@ -81,6 +81,32 @@ class FoundationalAPIClient:
         response.raise_for_status()
         return cast(dict[str, Any], response.json())
 
+    def get_pr_lineage_diff(
+            self,
+            repo_name: str,
+            pr_number: int,
+    ) -> dict[str, Any]:
+        params = dict(
+            repo_name=repo_name,
+            pr_number=pr_number,
+        )
+        response = self.get("lineage/pr/issues/diff", params=params)
+        response.raise_for_status()
+        return cast(dict[str, Any], response.json())
+
+    def get_pr_lineage_issues(
+            self,
+            repo_name: str,
+            pr_number: int,
+    ) -> dict[str, Any]:
+        params = dict(
+            repo_name=repo_name,
+            pr_number=pr_number,
+        )
+        response = self.get("lineage/pr/issues", params=params)
+        response.raise_for_status()
+        return cast(dict[str, Any], response.json())
+
     def get_downstream_dependencies(
             self,
             entity_id: str,

--- a/mcp/foundational_mcp_server.py
+++ b/mcp/foundational_mcp_server.py
@@ -79,6 +79,24 @@ def get_entity_details(entity_id: str) -> Dict[str, Any]:
     return client.get_entity_details(entity_id)
 
 @mcp.tool()
+def get_pr_lineage_diff(repo_name: str, pr_number: int) -> Dict[str, Any]:
+    """
+    Get lineage diff metadata for a pull request.
+    """
+    if client is None:
+        raise RuntimeError("API client not initialized")
+    return client.get_pr_lineage_diff(repo_name=repo_name, pr_number=pr_number)
+
+@mcp.tool()
+def get_pr_lineage_issues(repo_name: str, pr_number: int) -> Dict[str, Any]:
+    """
+    Get lineage issues for a pull request.
+    """
+    if client is None:
+        raise RuntimeError("API client not initialized")
+    return client.get_pr_lineage_issues(repo_name=repo_name, pr_number=pr_number)
+
+@mcp.tool()
 def get_downstream_dependencies(
     entity_id: str,
     name: Optional[str] = None,


### PR DESCRIPTION
## Summary
- add `get_pr_lineage_diff` and `get_pr_lineage_issues` methods to the Python Foundational API wrapper
- expose both new calls as MCP tools in `mcp/foundational_mcp_server.py`
- document supported endpoints in the README, including the new `/lineage/pr/issues/diff` path

## Test plan
- [x] Run `python -m py_compile hello_lineage_graph/foundational_api_wrapper.py mcp/foundational_mcp_server.py`
- [x] Confirm edited files are lint-clean
- [ ] Validate both PR endpoints against a live repository PR with API credentials

Made with [Cursor](https://cursor.com)