### PR TITLE
Add onboarding/offboarding API example; restructure into a package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy the entire project
 COPY . .
 
-# Ensure Python can find hello_lineage_graph
-ENV PYTHONPATH="/app:/app/hello_lineage_graph"
+# Ensure Python can find the foundational_api package and the example scripts
+ENV PYTHONPATH="/app"
 
 # Run the tests
 CMD ["python", "-m", "unittest", "discover", "-s", "tests"]

--- a/README.md
+++ b/README.md
@@ -15,8 +15,16 @@ cd lineage-api-examples
 Before running the examples, you need an API token. Follow the instructions here to generate your API key:
 [Creating an API Token](https://docs.foundational.io/en/articles/9920307-creating-api-token)
 
+### Repository Layout
+- `foundational_api/` — the shared `FoundationalAPIClient` wrapper used by every example.
+- `lineage_example.py` — lineage search + upstream/downstream dependencies example.
+- `onboarding_example.py` — onboarding / offboarding API example.
+- `foundational_mcp_server.py` — an MCP server exposing the lineage tools.
+
+Run the example scripts from the repository root so `from foundational_api import FoundationalAPIClient` resolves.
+
 ### Configure Your API Credentials
-Update the following variables in the `main.py` file under `hello_lineage_graph` folder:
+Update the following variables at the top of `lineage_example.py`:
 ```python
 ENTITY_NAME = "table_name_to_search_for"
 API_KEY_ID = "your_api_key_id"
@@ -33,7 +41,7 @@ You can run the example in two ways: directly on your machine or within Docker.
    ```
 2. Run the example script:
    ```sh
-   python hello_lineage_graph/main.py
+   python lineage_example.py
    ```
 
 ### Option 2: Run Within Docker
@@ -46,6 +54,25 @@ You can run the example in two ways: directly on your machine or within Docker.
    docker run --rm lineage-api-example
    ```
 
+### Onboarding / Offboarding Example
+`onboarding_example.py` shows how to use the onboarding API to list, onboard, and offboard repositories, and to manage the PowerBI workspaces scanned by your organization's PowerBI connector. It reuses the same `FoundationalAPIClient` wrapper from `foundational_api`.
+
+> **Note:** The onboarding API must be enabled for your organization. If it is not, these endpoints return HTTP 403 — contact [support@foundational.io](mailto:support@foundational.io) to enable it.
+
+1. Set your credentials (and, optionally, `REPO_NAME` / `POWERBI_WORKSPACE_ID`) at the top of `onboarding_example.py`:
+   ```python
+   API_KEY_ID = "your_api_key_id"
+   API_KEY_SECRET = "your_api_key_secret"
+   REPO_NAME = "my-org/my-repo"
+   POWERBI_WORKSPACE_ID = "11111111-2222-3333-4444-555555555555"
+   ```
+2. Run the example:
+   ```sh
+   python onboarding_example.py
+   ```
+
+By default `main()` only performs **read-only** calls (listing repositories and PowerBI workspaces) so it is safe to run as-is. The mutating operations — triggering onboarding, offboarding a repository, and adding/removing PowerBI workspaces — are provided as separate functions that are commented out in `main()`; uncomment them deliberately after setting the relevant constants.
+
 ### Option 3: Use MCP Server
 This repository includes an MCP server implementation that provides convenient access to the Foundational API. To use it:
 
@@ -56,7 +83,7 @@ This repository includes an MCP server implementation that provides convenient a
 
 2. Test that the server is running correctly by executing:
    ```sh
-   mcp run /path/to/lineage-api-examples/mcp/foundational_mcp_server.py
+   mcp run /path/to/lineage-api-examples/foundational_mcp_server.py
    ```
 
 3. Configure the MCP server in your AI assistant settings (e.g., Claude). Add the following configuration, replacing the paths and API credentials with your own:
@@ -67,7 +94,7 @@ This repository includes an MCP server implementation that provides convenient a
          "command": "/path/to/your/python/mcp",
          "args": [
            "run",
-           "/path/to/lineage-api-examples/mcp/foundational_mcp_server.py"
+           "/path/to/lineage-api-examples/foundational_mcp_server.py"
          ],
          "env": {
            "FOUNDATIONAL_API_KEY": "your-api-key",
@@ -87,11 +114,21 @@ The MCP server provides tools for:
 - retrieving pull request lineage issues
 
 ### Supported API Endpoints in This Repository
+
+Lineage:
 - `GET /lineage/search`
 - `GET /lineage/entity/{entity_id}`
 - `GET /lineage/entity/{entity_id}/{direction}`
 - `GET /lineage/pr/issues/diff`
 - `GET /lineage/pr/issues`
+
+Onboarding / Offboarding:
+- `GET /onboarding/repos`
+- `POST /onboarding/repos/{repo_name}/trigger`
+- `DELETE /onboarding/repos/{repo_name}`
+- `GET /onboarding/powerbi/workspaces`
+- `POST /onboarding/powerbi/workspaces`
+- `DELETE /onboarding/powerbi/workspaces/{workspace_id}`
 
 ## Additional Resources
 - Learn more about the API: [Getting Started with the Lineage API](https://docs.foundational.io/en/articles/10067204-getting-started-with-the-lineage-api)

--- a/foundational_api/__init__.py
+++ b/foundational_api/__init__.py
@@ -1,0 +1,11 @@
+from foundational_api.client import (
+    APICertification,
+    FoundationalAPIClient,
+    FoundationalAPIError,
+)
+
+__all__ = [
+    "APICertification",
+    "FoundationalAPIClient",
+    "FoundationalAPIError",
+]

--- a/foundational_api/client.py
+++ b/foundational_api/client.py
@@ -39,6 +39,16 @@ class FoundationalAPIClient:
         url = f"{self._base_url}/api/{self.API_VERSION}/{path}"
         return self.session.get(url, headers=headers, **kwargs)
 
+    def post(self, path: str, **kwargs: Any) -> requests.Response:
+        headers = self._generate_request_headers()
+        url = f"{self._base_url}/api/{self.API_VERSION}/{path}"
+        return self.session.post(url, headers=headers, **kwargs)
+
+    def delete(self, path: str, **kwargs: Any) -> requests.Response:
+        headers = self._generate_request_headers()
+        url = f"{self._base_url}/api/{self.API_VERSION}/{path}"
+        return self.session.delete(url, headers=headers, **kwargs)
+
     def search(
             self,
             entity_type: Literal["TABLE", "COLUMN", "DASHBOARD", "DASHBOARD_COLUMN"],
@@ -195,6 +205,76 @@ class FoundationalAPIClient:
         )
         params = {k: v for k, v in params.items() if v is not None}
         response = self.get(f"lineage/entity/{entity_id}/{direction}", params=params)
+        response.raise_for_status()
+        return cast(dict[str, Any], response.json())
+
+    # ------------------------------------------------------------------
+    # Onboarding / offboarding API (/api/v1/onboarding/...)
+    #
+    # The onboarding API must be enabled for your organization; when it is not,
+    # these endpoints respond with HTTP 403. Contact Foundational support to
+    # enable it.
+    # ------------------------------------------------------------------
+
+    def list_repos(self) -> dict[str, Any]:
+        """List the organization's repositories.
+
+        Includes offboarded repositories. Returns ``{"repos": ["org/repo", ...]}``.
+        """
+        response = self.get("onboarding/repos")
+        response.raise_for_status()
+        return cast(dict[str, Any], response.json())
+
+    def trigger_repo_onboarding(self, repo_name: str) -> None:
+        """Trigger (re-)onboarding for a repository.
+
+        ``repo_name`` is the repository full name, for example ``org/repository``.
+        If the repo was previously offboarded this brings it back before scanning.
+        Responds with HTTP 204 (no body); raises on 404 if the repo is not in the
+        caller's organization.
+        """
+        response = self.post(f"onboarding/repos/{repo_name}/trigger")
+        response.raise_for_status()
+
+    def offboard_repo(self, repo_name: str) -> None:
+        """Offboard a repository and its connectors.
+
+        ``repo_name`` is the repository full name, for example ``org/repository``.
+        Scan history is preserved and :meth:`trigger_repo_onboarding` brings the
+        repo back. Responds with HTTP 204 (no body); raises on 404 if the repo is
+        not in the caller's organization.
+        """
+        response = self.delete(f"onboarding/repos/{repo_name}")
+        response.raise_for_status()
+
+    def list_powerbi_workspaces(self) -> dict[str, Any]:
+        """List the workspace ids configured on the org's PowerBI connector.
+
+        Returns ``{"workspaceIds": ["<guid>", ...]}``. Raises on 404 if the org
+        has no PowerBI connector, or 409 if more than one is configured.
+        """
+        response = self.get("onboarding/powerbi/workspaces")
+        response.raise_for_status()
+        return cast(dict[str, Any], response.json())
+
+    def add_powerbi_workspace(self, workspace_id: str) -> dict[str, Any]:
+        """Add a workspace id (a GUID) to the org's PowerBI connector.
+
+        Idempotent: a no-op if the workspace is already configured. Returns the
+        updated ``{"workspaceIds": [...]}`` list.
+        """
+        response = self.post("onboarding/powerbi/workspaces", json={"workspaceId": workspace_id})
+        response.raise_for_status()
+        return cast(dict[str, Any], response.json())
+
+    def remove_powerbi_workspace(self, workspace_id: str) -> dict[str, Any]:
+        """Remove a workspace id (a GUID) from the org's PowerBI connector.
+
+        Idempotent: a no-op (not a 404) if the id is absent. Removing the last id
+        resets the connector to autodiscovering all authorized workspaces. Returns
+        the updated ``{"workspaceIds": [...]}`` list.
+        """
+        response = self.delete(f"onboarding/powerbi/workspaces/{workspace_id}")
         response.raise_for_status()
         return cast(dict[str, Any], response.json())
 

--- a/foundational_mcp_server.py
+++ b/foundational_mcp_server.py
@@ -2,10 +2,7 @@ import os
 import sys
 from typing import Any, Dict, List, Literal, Optional, Union
 
-# Add to sys path the hello_lineage_graph directory
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-
-from hello_lineage_graph.foundational_api_wrapper import FoundationalAPIClient
+from foundational_api import FoundationalAPIClient
 from mcp.server.fastmcp import FastMCP
 
 mcp = FastMCP("Foundational Data MCP")

--- a/foundational_mcp_server.py
+++ b/foundational_mcp_server.py
@@ -2,6 +2,10 @@ import os
 import sys
 from typing import Any, Dict, List, Literal, Optional, Union
 
+# `mcp run <path>` loads this file by path and does not add its directory to
+# sys.path, so add the repo root here to make the import resolve from any cwd.
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
 from foundational_api import FoundationalAPIClient
 from mcp.server.fastmcp import FastMCP
 

--- a/lineage_example.py
+++ b/lineage_example.py
@@ -1,4 +1,4 @@
-from foundational_api_wrapper import FoundationalAPIClient
+from foundational_api import FoundationalAPIClient
 
 # Constants
 ENTITY_TYPE = "TABLE"  # Example entity type

--- a/onboarding_example.py
+++ b/onboarding_example.py
@@ -1,0 +1,99 @@
+import requests
+
+from foundational_api import FoundationalAPIClient
+
+# Constants — fill these in with your own values.
+API_KEY_ID = "your_api_key_id"
+API_KEY_SECRET = "your_api_key_secret"
+
+# A repository full name as it appears in your organization, e.g. "my-org/my-repo".
+REPO_NAME = "my-org/my-repo"
+
+# A PowerBI workspace id (a GUID). Only relevant if your organization has a
+# PowerBI connector configured.
+POWERBI_WORKSPACE_ID = "11111111-2222-3333-4444-555555555555"
+
+
+def list_repos_example(api_client: FoundationalAPIClient) -> None:
+    """Read-only: list every repository in the organization (including offboarded ones)."""
+    result = api_client.list_repos()
+    repos = result.get("repos", [])
+    print(f"\nOrganization has {len(repos)} repositories:")
+    for repo in repos:
+        print(f"  - {repo}")
+
+
+def list_powerbi_workspaces_example(api_client: FoundationalAPIClient) -> None:
+    """Read-only: list the workspaces configured on the org's PowerBI connector.
+
+    Skips gracefully if the organization has no PowerBI connector (HTTP 404).
+    """
+    try:
+        result = api_client.list_powerbi_workspaces()
+    except requests.HTTPError as error:
+        if error.response is not None and error.response.status_code == 404:
+            print("\nNo PowerBI connector configured for this organization; skipping.")
+            return
+        raise
+
+    workspace_ids = result.get("workspaceIds", [])
+    print(f"\nPowerBI connector has {len(workspace_ids)} configured workspaces:")
+    for workspace_id in workspace_ids:
+        print(f"  - {workspace_id}")
+
+
+def trigger_onboarding_example(api_client: FoundationalAPIClient) -> None:
+    """Mutating: (re-)onboard REPO_NAME, reviving it if it was previously offboarded.
+
+    Not called by default — uncomment the call in main() to run it.
+    """
+    api_client.trigger_repo_onboarding(REPO_NAME)
+    print(f"\nTriggered onboarding for '{REPO_NAME}'.")
+
+
+def offboard_repo_example(api_client: FoundationalAPIClient) -> None:
+    """Mutating: offboard REPO_NAME and its connectors.
+
+    Not called by default — uncomment the call in main() to run it. Scan history
+    is preserved; re-trigger onboarding to bring the repo back.
+    """
+    api_client.offboard_repo(REPO_NAME)
+    print(f"\nOffboarded '{REPO_NAME}'.")
+
+
+def add_powerbi_workspace_example(api_client: FoundationalAPIClient) -> None:
+    """Mutating: add POWERBI_WORKSPACE_ID to the org's PowerBI connector.
+
+    Not called by default — uncomment the call in main() to run it.
+    """
+    result = api_client.add_powerbi_workspace(POWERBI_WORKSPACE_ID)
+    print(f"\nAdded {POWERBI_WORKSPACE_ID}. Configured workspaces: {result.get('workspaceIds', [])}")
+
+
+def remove_powerbi_workspace_example(api_client: FoundationalAPIClient) -> None:
+    """Mutating: remove POWERBI_WORKSPACE_ID from the org's PowerBI connector.
+
+    Not called by default — uncomment the call in main() to run it.
+    """
+    result = api_client.remove_powerbi_workspace(POWERBI_WORKSPACE_ID)
+    print(f"\nRemoved {POWERBI_WORKSPACE_ID}. Configured workspaces: {result.get('workspaceIds', [])}")
+
+
+def main() -> None:
+    api_client = FoundationalAPIClient(API_KEY_ID, API_KEY_SECRET)
+
+    # Read-only examples — safe to run as-is.
+    list_repos_example(api_client)
+    list_powerbi_workspaces_example(api_client)
+
+    # Mutating examples — these change your organization's configuration and
+    # trigger scans. Uncomment deliberately, after setting the constants above.
+    #
+    # trigger_onboarding_example(api_client)
+    # offboard_repo_example(api_client)
+    # add_powerbi_workspace_example(api_client)
+    # remove_powerbi_workspace_example(api_client)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -1,21 +1,17 @@
 import unittest
 from unittest.mock import patch
 from io import StringIO
-import sys
-import os
 
-TESTS_PATH = os.getcwd()
-SAMPLES_PATH = os.path.join(TESTS_PATH, '..', 'hello_lineage_graph')
-sys.path.append(SAMPLES_PATH)
+from lineage_example import main
 
-from hello_lineage_graph.main import main  # Adjust import based on your actual structure
 
-class TestMain(unittest.TestCase):  # Use 'class' and 'unittest.TestCase'
+class TestMain(unittest.TestCase):
 
     @patch('sys.stdout', new_callable=StringIO)
-    def test_main(self, mock_stdout):  # Use 'self' and 'mock_stdout'
-        # Call the main function, and just verifies it doesn't crash :)
+    def test_main(self, mock_stdout):
+        # Call the main function, and just verify it doesn't crash :)
         main()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## What

Adds an example for the **onboarding / offboarding API** and cleans up the repo layout.

### Onboarding API support
- Extends the shared `FoundationalAPIClient` with `POST`/`DELETE` helpers and six onboarding methods:
  - `list_repos()` → `GET /onboarding/repos`
  - `trigger_repo_onboarding(repo)` → `POST /onboarding/repos/{repo}/trigger`
  - `offboard_repo(repo)` → `DELETE /onboarding/repos/{repo}`
  - `list_powerbi_workspaces()` → `GET /onboarding/powerbi/workspaces`
  - `add_powerbi_workspace(id)` → `POST /onboarding/powerbi/workspaces`
  - `remove_powerbi_workspace(id)` → `DELETE /onboarding/powerbi/workspaces/{id}`
- New `onboarding_example.py`. `main()` runs **read-only** calls (list repos, list PowerBI workspaces) so it's safe to run as-is; the mutating operations (trigger, offboard, add/remove workspace) are separate.

### Repository restructure
- Moved the wrapper into a `foundational_api/` package (`client.py` + `__init__.py` re-export)
- Example scripts now live at the repo root (`lineage_example.py`, `onboarding_example.py`)
- Moved the MCP server out of the `mcp/` folder (`foundational_mcp_server.py`), which also avoids shadowing the `mcp` pip package.
- Updated `tests/test_samples.py`, the `Dockerfile` `PYTHONPATH`, and the README (paths + a new Repository Layout section).